### PR TITLE
Fix 'Failed to fetch package release urls' problem

### DIFF
--- a/bin/pip.py
+++ b/bin/pip.py
@@ -892,7 +892,7 @@ class PyPIRepository(PackageRepository):
     def get_standard_package_name(self, pkg_name):
         if pkg_name not in self.standard_package_names:
             try:
-                r = requests.get('http://pypi.python.org/pypi/{}/json'.format(pkg_name))
+                r = requests.get('https://pypi.org/pypi/{}/json'.format(pkg_name))
                 self.standard_package_names[pkg_name] = r.json()['info']['name']
             except:
                 return pkg_name
@@ -912,7 +912,7 @@ class PyPIRepository(PackageRepository):
         return hits
 
     def _package_data(self, pkg_name):
-        r = requests.get('http://pypi.python.org/pypi/{}/json'.format(pkg_name))
+        r = requests.get('https://pypi.org/pypi/{}/json'.format(pkg_name))
         if not r.status_code == requests.codes.ok:
             raise PipError('Failed to fetch package release urls')
 


### PR DESCRIPTION
PyPi API is changed. I update the new link--'https://pypi.org/pypi/{}/json'.